### PR TITLE
Some clang-tidy fixes:

### DIFF
--- a/src/assembly/parser.hpp
+++ b/src/assembly/parser.hpp
@@ -102,4 +102,4 @@ class AssemblyTextParser : public IParser
     void outputDebugJson(std::ostream &out) const override;
 };
 
-}; // namespace AsmParser
+} // namespace AsmParser

--- a/src/objdump/parser.cpp
+++ b/src/objdump/parser.cpp
@@ -21,7 +21,7 @@ void AsmParser::ObjDumpParserState::commonReset()
     this->skipRestOfTheLine = false;
 }
 
-AsmParser::ObjDumpParser::ObjDumpParser(const Filter filter) : filter(filter)
+AsmParser::ObjDumpParser::ObjDumpParser(const Filter &filter) : filter(filter)
 {
 }
 
@@ -408,12 +408,12 @@ void AsmParser::ObjDumpParser::outputDebugJson(std::ostream &out) const
 {
     out << "Not implemented"
         << "\n";
-    throw "Not implemented";
+    throw std::runtime_error("Not implemented");
 }
 
 void AsmParser::ObjDumpParser::outputText(std::ostream &out) const
 {
-    for (auto line : this->lines)
+    for (const auto &line : this->lines)
     {
         out << line.text << "\n";
     }

--- a/src/objdump/parser.hpp
+++ b/src/objdump/parser.hpp
@@ -49,7 +49,7 @@ class ObjDumpParser : public IParser
     void actually_address();
     void actually_filename();
 
-    bool shouldIgnoreFunction(const std::string_view name) const;
+    bool shouldIgnoreFunction(std::string_view name) const;
     void eol();
     void address();
     void opcodes();
@@ -57,7 +57,7 @@ class ObjDumpParser : public IParser
     void labelref();
 
     public:
-    ObjDumpParser(const Filter filter);
+    explicit ObjDumpParser(const Filter &filter);
 
     void fromStream(std::istream &in) override;
 
@@ -67,4 +67,4 @@ class ObjDumpParser : public IParser
     void outputDebugJson(std::ostream &out) const override;
 };
 
-}; // namespace AsmParser
+} // namespace AsmParser

--- a/src/types/parser.hpp
+++ b/src/types/parser.hpp
@@ -16,4 +16,4 @@ class IParser
     virtual void outputDebugJson(std::ostream &out) const = 0;
 };
 
-}; // namespace AsmParser
+} // namespace AsmParser

--- a/src/utils/jsonwriter.cpp
+++ b/src/utils/jsonwriter.cpp
@@ -1,13 +1,14 @@
 #include "jsonwriter.hpp"
 #include <algorithm>
 #include <ostream>
+#include <utility>
 #include "utils.hpp"
 
 AsmParser::JsonWriter::JsonWriter(std::ostream &out,
                                   const std::vector<std::unique_ptr<asm_line_v>> &lines,
-                                  const std::vector<asm_labelpair> &labels,
+                                  std::vector<asm_labelpair> labels,
                                   const Filter filter)
-: filter(filter), out(out), lines(lines), labels(labels), prettyPrint(false)
+: filter(filter), out(out), lines(lines), labels(std::move(labels)), prettyPrint(false)
 {
 }
 
@@ -391,13 +392,13 @@ void AsmParser::JsonWriter::JsonWriter::write()
 AsmParser::DebugJsonWriter::DebugJsonWriter(std::ostream &out,
                                             const std::vector<std::unique_ptr<asm_line_v>> &lines,
                                             const std::vector<asm_labelpair> &labels,
-                                            const Filter filter,
-                                            const std::unordered_map<std::string_view, std::unordered_set<std::string_view>> used_labels,
-                                            const std::unordered_map<std::string_view, std::unordered_set<std::string_view>> used_weak_labels,
-                                            const std::unordered_map<std::string_view, std::string_view> aliased_labels,
-                                            const std::unordered_map<std::string_view, std::unordered_set<std::string_view>> used_data_labels)
-: AsmParser::JsonWriter::JsonWriter(out, lines, labels, filter), used_labels(used_labels),
-  used_weak_labels(used_weak_labels), aliased_labels(aliased_labels), used_data_labels(used_data_labels)
+                                            const Filter &filter,
+                                            std::unordered_map<std::string_view, std::unordered_set<std::string_view>>  used_labels,
+                                            std::unordered_map<std::string_view, std::unordered_set<std::string_view>>  used_weak_labels,
+                                            std::unordered_map<std::string_view, std::string_view>  aliased_labels,
+                                            std::unordered_map<std::string_view, std::unordered_set<std::string_view>>  used_data_labels)
+: AsmParser::JsonWriter::JsonWriter(out, lines, labels, filter), used_labels(std::move(used_labels)),
+  used_weak_labels(std::move(used_weak_labels)), aliased_labels(std::move(aliased_labels)), used_data_labels(std::move(used_data_labels))
 {
 }
 

--- a/src/utils/jsonwriter.cpp
+++ b/src/utils/jsonwriter.cpp
@@ -9,7 +9,7 @@ AsmParser::JsonWriter::JsonWriter(std::ostream &out,
                                   const std::vector<std::unique_ptr<asm_line_v>> &lines,
                                   std::vector<asm_labelpair> labels,
                                   const Filter filter)
-: filter(filter), out(out), lines(lines), labels(std::move(labels)), prettyPrint(false)
+: filter(filter), out(out), lines(lines), labels(labels), prettyPrint(false)
 {
 }
 
@@ -401,8 +401,8 @@ AsmParser::DebugJsonWriter::DebugJsonWriter(std::ostream &out,
                                             std::unordered_map<std::string_view, std::unordered_set<std::string_view>>  used_weak_labels,
                                             std::unordered_map<std::string_view, std::string_view>  aliased_labels,
                                             std::unordered_map<std::string_view, std::unordered_set<std::string_view>>  used_data_labels)
-: AsmParser::JsonWriter::JsonWriter(out, lines, labels, filter), used_labels(std::move(used_labels)),
-  used_weak_labels(std::move(used_weak_labels)), aliased_labels(std::move(aliased_labels)), used_data_labels(std::move(used_data_labels))
+: AsmParser::JsonWriter::JsonWriter(out, lines, labels, filter), used_labels(used_labels),
+  used_weak_labels(used_weak_labels), aliased_labels(aliased_labels), used_data_labels(used_data_labels)
 {
 }
 

--- a/src/utils/jsonwriter.hpp
+++ b/src/utils/jsonwriter.hpp
@@ -46,7 +46,7 @@ class JsonWriter
     public:
     JsonWriter(std::ostream &out,
                const std::vector<std::unique_ptr<asm_line_v>> &lines,
-               const std::vector<asm_labelpair> &labels,
+               std::vector<asm_labelpair> labels,
                const Filter filter);
 
     virtual void write();
@@ -66,11 +66,11 @@ class DebugJsonWriter : public JsonWriter
     DebugJsonWriter(std::ostream &out,
                     const std::vector<std::unique_ptr<asm_line_v>> &lines,
                     const std::vector<asm_labelpair> &labels,
-                    const Filter filter,
-                    const std::unordered_map<std::string_view, std::unordered_set<std::string_view>> used_labels,
-                    const std::unordered_map<std::string_view, std::unordered_set<std::string_view>> used_weak_labels,
-                    const std::unordered_map<std::string_view, std::string_view> aliased_labels,
-                    const std::unordered_map<std::string_view, std::unordered_set<std::string_view>> used_data_labels);
+                    const Filter &filter,
+                    std::unordered_map<std::string_view, std::unordered_set<std::string_view>>  used_labels,
+                    std::unordered_map<std::string_view, std::unordered_set<std::string_view>>  used_weak_labels,
+                    std::unordered_map<std::string_view, std::string_view>  aliased_labels,
+                    std::unordered_map<std::string_view, std::unordered_set<std::string_view>>  used_data_labels);
 
     void write() override;
 };

--- a/src/utils/regexes.hpp
+++ b/src/utils/regexes.hpp
@@ -60,4 +60,4 @@ struct Regexes
 };
 
 
-}; // namespace AsmParser
+} // namespace AsmParser

--- a/src/utils/regexwrappers.cpp
+++ b/src/utils/regexwrappers.cpp
@@ -280,9 +280,9 @@ bool AsmParser::AssemblyTextParserUtils::hasOpcode(const std::string_view line, 
         return false;
 
     if (inNvccCode)
-        return !!Regexes::hasNvccOpcodeRe(lineWithoutComment);
+        return Regexes::hasNvccOpcodeRe(lineWithoutComment);
 
-    return !!Regexes::hasOpcodeRe(lineWithoutComment);
+    return Regexes::hasOpcodeRe(lineWithoutComment);
 }
 
 bool AsmParser::AssemblyTextParserUtils::isExampleOrStdin(const std::string_view filename)
@@ -302,9 +302,9 @@ std::optional<AsmParser::asm_stabn> AsmParser::AssemblyTextParserUtils::getSourc
     const auto type = svtoi(match.get<1>().to_view());
     if (type == 68)
     {
-        const auto line = svtoi(match.get<2>().to_view());
+        const auto line_num = svtoi(match.get<2>().to_view());
 
-        return asm_stabn{ type, line };
+        return asm_stabn{ type, line_num };
     }
     else
     {
@@ -342,9 +342,9 @@ std::optional<AsmParser::asm_source_l> AsmParser::AssemblyTextParserUtils::getD2
     const auto match = Regexes::sourceD2Tag(line);
     if (match)
     {
-        const auto line = svtoi(match.get<1>().to_view());
+        const auto line_num = svtoi(match.get<1>().to_view());
 
-        return asm_source_l{ .line = line };
+        return asm_source_l{ .line = line_num };
     }
 
     return std::nullopt;

--- a/src/utils/regexwrappers.hpp
+++ b/src/utils/regexwrappers.hpp
@@ -19,58 +19,58 @@ struct regexed_sourceref
 class AssemblyTextParserUtils
 {
     public:
-    static regexed_sourceref getSourceRef(const std::string_view line);
-    static std::optional<AsmParser::asm_file_def> getFileDef(const std::string_view line);
-    static bool is_probably_label(const std::string_view line);
-    static std::string fixLabelIndentation(const std::string_view line);
-    static std::string_view getLineWithoutComment(const std::string_view line);
-    static std::string_view getLineWithoutCommentAndStripFirstWord(const std::string_view line);
+    static regexed_sourceref getSourceRef(std::string_view line);
+    static std::optional<AsmParser::asm_file_def> getFileDef(std::string_view line);
+    static bool is_probably_label(std::string_view line);
+    static std::string fixLabelIndentation(std::string_view line);
+    static std::string_view getLineWithoutComment(std::string_view line);
+    static std::string_view getLineWithoutCommentAndStripFirstWord(std::string_view line);
 
-    static std::string expandTabs(const std::string_view line);
+    static std::string expandTabs(std::string_view line);
 
-    static std::string squashHorizontalWhitespace(const std::string_view line, bool atStart = true);
-    static std::string squashHorizontalWhitespaceWithQuotes(const std::string_view line, bool atStart);
+    static std::string squashHorizontalWhitespace(std::string_view line, bool atStart = true);
+    static std::string squashHorizontalWhitespaceWithQuotes(std::string_view line, bool atStart);
 
-    static std::vector<AsmParser::asm_label_v> getUsedLabelsInLine(const std::string_view line);
+    static std::vector<AsmParser::asm_label_v> getUsedLabelsInLine(std::string_view line);
 
-    static bool hasOpcode(const std::string_view line, bool inNvccCode);
+    static bool hasOpcode(std::string_view line, bool inNvccCode);
 
-    static bool isExampleOrStdin(const std::string_view filename);
+    static bool isExampleOrStdin(std::string_view filename);
 
-    static bool isJustComments(const std::string_view line);
-    static bool isJustNvccComments(const std::string_view line);
+    static bool isJustComments(std::string_view line);
+    static bool isJustNvccComments(std::string_view line);
 
-    static std::optional<AsmParser::asm_stabn> getSourceInfoFromStabs(const std::string_view line);
-    static std::optional<AsmParser::asm_source_v> get6502DbgInfo(const std::string_view line);
+    static std::optional<AsmParser::asm_stabn> getSourceInfoFromStabs(std::string_view line);
+    static std::optional<AsmParser::asm_source_v> get6502DbgInfo(std::string_view line);
 
-    static std::optional<AsmParser::asm_source_f> getD2FileInfo(const std::string_view line);
-    static std::optional<AsmParser::asm_source_l> getD2LineInfo(const std::string_view line);
+    static std::optional<AsmParser::asm_source_f> getD2FileInfo(std::string_view line);
+    static std::optional<AsmParser::asm_source_l> getD2LineInfo(std::string_view line);
 
-    static std::optional<std::string_view> getLabel(const std::string_view line);
-    static std::optional<std::string_view> getAssignmentDef(const std::string_view line);
-    static std::optional<std::string_view> getLabelAssignment(const std::string_view line);
-    static std::optional<std::string_view> getCudaLabel(const std::string_view line);
-    static std::optional<std::string_view> getFunctionTypeDefinedLabel(const std::string_view line);
-    static std::optional<std::string_view> getWeakDefinedLabel(const std::string_view line);
-    static std::optional<std::string_view> getGlobalDefinedLabel(const std::string_view line);
-    static std::optional<std::string_view> getSectionNameDef(const std::string_view line);
+    static std::optional<std::string_view> getLabel(std::string_view line);
+    static std::optional<std::string_view> getAssignmentDef(std::string_view line);
+    static std::optional<std::string_view> getLabelAssignment(std::string_view line);
+    static std::optional<std::string_view> getCudaLabel(std::string_view line);
+    static std::optional<std::string_view> getFunctionTypeDefinedLabel(std::string_view line);
+    static std::optional<std::string_view> getWeakDefinedLabel(std::string_view line);
+    static std::optional<std::string_view> getGlobalDefinedLabel(std::string_view line);
+    static std::optional<std::string_view> getSectionNameDef(std::string_view line);
 
-    static bool startCommentBlock(const std::string_view line);
-    static bool endCommentBlock(const std::string_view line);
+    static bool startCommentBlock(std::string_view line);
+    static bool endCommentBlock(std::string_view line);
 
-    static bool startAppBlock(const std::string_view line);
-    static bool endAppBlock(const std::string_view line);
-    static bool startAsmNesting(const std::string_view line);
-    static bool endAsmNesting(const std::string_view line);
+    static bool startAppBlock(std::string_view line);
+    static bool endAppBlock(std::string_view line);
+    static bool startAsmNesting(std::string_view line);
+    static bool endAsmNesting(std::string_view line);
 
-    static bool startProcBlock(const std::string_view line);
-    static bool endBlock(const std::string_view line);
-    static bool endProcBlock(const std::string_view line);
+    static bool startProcBlock(std::string_view line);
+    static bool endBlock(std::string_view line);
+    static bool endProcBlock(std::string_view line);
 
-    static bool isCudaEndDef(const std::string_view line);
-    static bool isDataDefn(const std::string_view line);
-    static bool isDirective(const std::string_view line);
-    static bool isInstOpcode(const std::string_view line);
+    static bool isCudaEndDef(std::string_view line);
+    static bool isDataDefn(std::string_view line);
+    static bool isDirective(std::string_view line);
+    static bool isInstOpcode(std::string_view line);
 };
 
-}; // namespace AsmParser
+} // namespace AsmParser

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -22,7 +22,7 @@ size_t AsmParser::ustrlen(const std::string_view s)
 {
     const char *cstrptr = s.data();
 
-    mblen(NULL, 0);
+    mblen(nullptr, 0);
 
     size_t maxlen = s.length();
 

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -10,10 +10,10 @@ inline bool is_whitespace(const char c)
     return ((c == 32) || (c == '\t'));
 }
 
-bool is_hex(const char c);
-int8_t hex2int(const char c);
+bool is_hex(char c);
+int8_t hex2int(char c);
 
-size_t ustrlen(const std::string_view s);
+size_t ustrlen(std::string_view s);
 
 void global_start_timer();
 int64_t global_current_running_time();


### PR DESCRIPTION
* const parameters in declarations are not recommended;
  "const int x" is the same as "int x" for overload resolution.
  It's fine in definitions though.
* Various minor warnings and unused things.