### PR TITLE
Objdump librarycode filter

### DIFF
--- a/resources/demangled_tiny.asm
+++ b/resources/demangled_tiny.asm
@@ -1,0 +1,95 @@
+
+output.s:     file format elf64-x86-64
+
+
+Disassembly of section .init:
+
+0000000000408000 <_init>:
+_init():
+  408000:	f3 0f 1e fa                                     	endbr64 
+  40801a:	c3                                              	ret    
+
+Disassembly of section .plt:
+
+0000000000408020 <std::basic_ios<char, std::char_traits<char> >::fail() const@plt-0x10>:
+  408020:	ff 35 e2 af 13 00                               	push   QWORD PTR [rip+0x13afe2]        # 543008 <_GLOBAL_OFFSET_TABLE_+0x8>
+  408026:	ff 25 e4 af 13 00                               	jmp    QWORD PTR [rip+0x13afe4]        # 543010 <_GLOBAL_OFFSET_TABLE_+0x10>
+  40802c:	0f 1f 40 00                                     	nop    DWORD PTR [rax+0x0]
+
+0000000000408030 <std::basic_ios<char, std::char_traits<char> >::fail() const@plt>:
+  408030:	ff 25 e2 af 13 00                               	jmp    QWORD PTR [rip+0x13afe2]        # 543018 <std::basic_ios<char, std::char_traits<char> >::fail() const@GLIBCXX_3.4>
+  408036:	68 00 00 00 00                                  	push   0x0
+  40803b:	e9 e0 ff ff ff                                  	jmp    408020 <_init+0x20>
+
+Disassembly of section .text:
+
+0000000000408f70 <____C_A_T_C_H____T_E_S_T____0() [clone .cold]>:
+____C_A_T_C_H____T_E_S_T____0() [clone .cold]:
+  408f70:	90                                              	nop
+/app/example.cpp:31
+  408f71:	48 89 c5                                        	mov    rbp,rax
+____C_A_T_C_H____T_E_S_T____0():
+/app/example.cpp:31 (discriminator 17)
+  408f74:	48 8d 7c 24 70                                  	lea    rdi,[rsp+0x70]
+  408f79:	e8 72 27 00 00                                  	call   40b6f0 <Catch::AssertionHandler::~AssertionHandler()>
+/app/example.cpp:32
+  408f7e:	48 8d bc 24 c0 00 00 00                         	lea    rdi,[rsp+0xc0]
+  408f86:	e8 fd 19 04 00                                  	call   44a988 <Catch::Section::~Section()>
+  408f8b:	48 89 ef                                        	mov    rdi,rbp
+  408f8e:	e8 1d fe ff ff                                  	call   408db0 <_Unwind_Resume@plt>
+Catch::BinaryExpr<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const (&) [2]>::~BinaryExpr():
+/opt/compiler-explorer/libs/catch2/v3.0.0-preview2/src/catch2/internal/catch_decomposer.hpp:65 (discriminator 8)
+  408f93:	48 c7 44 24 40 20 73 4c 00                      	mov    QWORD PTR [rsp+0x40],0x4c7320
+  408f9c:	48 8d 7c 24 40                                  	lea    rdi,[rsp+0x40]
+  408fa1:	e8 32 e6 02 00                                  	call   4375d8 <Catch::ITransientExpression::~ITransientExpression()>
+____C_A_T_C_H____T_E_S_T____0():
+/app/example.cpp:23 (discriminator 2)
+  408fb8:	e8 33 f3 ff ff                                  	call   4082f0 <__cxa_begin_catch@plt>
+  408fbd:	48 8d 7c 24 70                                  	lea    rdi,[rsp+0x70]
+  408fc2:	e8 3b 29 00 00                                  	call   40b902 <Catch::AssertionHandler::handleUnexpectedInflightException()>
+____C_A_T_C_H____T_E_S_T____0() [clone .cold]:
+  4095af:	90                                              	nop
+
+00000000004095b0 <_GLOBAL__sub_I__Z8fizzbuzzB5cxx11i>:
+_GLOBAL__sub_I__Z8fizzbuzzB5cxx11i():
+/app/example.cpp:52
+  4095b0:	48 83 ec 78                                     	sub    rsp,0x78
+/app/example.cpp:19
+  4095b4:	be 82 71 4c 00                                  	mov    esi,0x4c7182
+__static_initialization_and_destruction_0():
+/app/example.cpp:19
+  4095b9:	48 8d 7c 24 10                                  	lea    rdi,[rsp+0x10]
+  4095be:	e8 d3 94 05 00                                  	call   462a96 <Catch::StringRef::StringRef(char const*)>
+  4095c3:	be 91 71 4c 00                                  	mov    esi,0x4c7191
+  4095c8:	48 8d 7c 24 20                                  	lea    rdi,[rsp+0x20]
+  4095cd:	e8 c4 94 05 00                                  	call   462a96 <Catch::StringRef::StringRef(char const*)>
+Catch::NameAndTags::NameAndTags(Catch::StringRef const&, Catch::StringRef const&):
+/opt/compiler-explorer/libs/catch2/v3.0.0-preview2/src/catch2/internal/catch_test_registry.hpp:51
+  4095d2:	66 0f 6f 44 24 10                               	movdqa xmm0,XMMWORD PTR [rsp+0x10]
+  4095d8:	66 0f 6f 4c 24 20                               	movdqa xmm1,XMMWORD PTR [rsp+0x20]
+__static_initialization_and_destruction_0():
+/app/example.cpp:19
+  4095de:	be 70 9b 40 00                                  	mov    esi,0x409b70
+  4095e3:	48 c7 44 24 38 00 00 00 00                      	mov    QWORD PTR [rsp+0x38],0x0
+  4095ec:	48 8d 7c 24 08                                  	lea    rdi,[rsp+0x8]
+_GLOBAL__sub_I__Z8fizzbuzzB5cxx11i():
+/app/example.cpp:52
+  409649:	48 83 c4 78                                     	add    rsp,0x78
+  40964d:	c3                                              	ret    
+  40964e:	66 90                                           	xchg   ax,ax
+
+000000000040b0f0 <Catch::BinaryExpr<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const (&) [2]>::~BinaryExpr()>:
+Catch::BinaryExpr<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const (&) [2]>::~BinaryExpr():
+/opt/compiler-explorer/libs/catch2/v3.0.0-preview2/src/catch2/internal/catch_decomposer.hpp:65
+  40b0f0:	48 c7 07 20 73 4c 00                            	mov    QWORD PTR [rdi],0x4c7320
+  40b0f7:	e9 dc c4 02 00                                  	jmp    4375d8 <Catch::ITransientExpression::~ITransientExpression()>
+  40b0fc:	0f 1f 40 00                                     	nop    DWORD PTR [rax+0x0]
+
+Disassembly of section .fini:
+
+00000000004c60f8 <_fini>:
+_fini():
+  4c60f8:	f3 0f 1e fa                                     	endbr64 
+  4c60fc:	48 83 ec 08                                     	sub    rsp,0x8
+  4c6100:	48 83 c4 08                                     	add    rsp,0x8
+  4c6104:	c3                                              	ret    

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(asm-parser-lib STATIC
     utils/utils.cpp
     utils/jsonwriter.cpp
     utils/regexwrappers.cpp
+    utils/library_detection.cpp
     objdump/parser.cpp
     assembly/parser.cpp
 )

--- a/src/objdump/parser.cpp
+++ b/src/objdump/parser.cpp
@@ -243,7 +243,8 @@ void AsmParser::ObjDumpParser::do_file_check(std::string_view filename)
     {
         this->state.checkNextFileForLibraryCode = false;
 
-        if (AssemblyTextParserUtils::isProbablyLibraryFile(filename))
+
+        if (this->lib_detection.file_in_library(filename))
         {
             if (this->lines.size() > 0)
             {

--- a/src/objdump/parser.cpp
+++ b/src/objdump/parser.cpp
@@ -220,6 +220,20 @@ void AsmParser::ObjDumpParser::actually_address()
     }
 }
 
+void AsmParser::ObjDumpParser::undo_last_line_if_label()
+{
+    const auto lastLine = this->lines.back();
+    if (lastLine.is_label)
+    {
+        std::erase_if(this->labels,
+                        [lastLine](auto &label)
+                        {
+                            return label.first == lastLine.label;
+                        });
+        this->lines.pop_back();
+    }
+}
+
 void AsmParser::ObjDumpParser::do_file_check(std::string_view filename)
 {
     if (this->state.checkNextFileForLibraryCode)
@@ -231,16 +245,7 @@ void AsmParser::ObjDumpParser::do_file_check(std::string_view filename)
             if (this->lines.size() > 0)
             {
                 // undo previous line if that was a label (it's a label in a library file)
-                const auto lastLine = this->lines.back();
-                if (lastLine.is_label)
-                {
-                    std::erase_if(this->labels,
-                                  [lastLine](auto &label)
-                                  {
-                                      return label.first == lastLine.label;
-                                  });
-                    this->lines.pop_back();
-                }
+                undo_last_line_if_label()
             }
 
             this->state.commonReset();

--- a/src/objdump/parser.cpp
+++ b/src/objdump/parser.cpp
@@ -86,7 +86,7 @@ void AsmParser::ObjDumpParser::eol()
 
         if (lines.size() < 5000)
         {
-        lines.push_back(this->state.currentLine);
+            lines.push_back(this->state.currentLine);
         }
         else
         {
@@ -195,6 +195,10 @@ void AsmParser::ObjDumpParser::actually_address()
             auto hint = hex2int(*c);
             if (hint != 0)
             {
+                // note: the if works for cases in 64 bit objdumps where label lines are formatted like this "0000000000408000 <_init>:"
+                //  because it most likely won't get to the last/first hex chunk this way.
+                //  Otherwise makes gcc think it's gonna be bigger than a int64_t and complain about potential overflows.
+                //  (or maybe some other bit of the code is wrong??)
                 addr += hint << bitsdone;
             }
             bitsdone += 4;

--- a/src/objdump/parser.cpp
+++ b/src/objdump/parser.cpp
@@ -181,12 +181,17 @@ void AsmParser::ObjDumpParser::actually_address()
         int8_t bitsdone = 0;
         for (auto c = this->state.text.rbegin(); c != this->state.text.rend(); c++)
         {
-            if (!is_hex(*c)) {
+            if (!is_hex(*c))
+            {
                 maybeNotHexAfterall = true;
                 break;
             }
 
-            addr += hex2int(*c) << bitsdone;
+            auto hint = hex2int(*c);
+            if (hint != 0)
+            {
+                addr += hint << bitsdone;
+            }
             bitsdone += 4;
         }
 

--- a/src/objdump/parser.cpp
+++ b/src/objdump/parser.cpp
@@ -134,14 +134,17 @@ void AsmParser::ObjDumpParser::labelref()
     if (!this->state.ignoreUntilNextLabel)
     {
         this->state.currentLabelReference.range.end_col = ustrlen(this->state.text);
-        try {
+        try
+        {
             this->state.currentLabelReference.name = this->state.text.substr(this->state.currentLabelReference.range.start_col);
 
             if (!this->shouldIgnoreFunction(this->state.currentLabelReference.name))
             {
                 this->state.currentLine.labels.push_back(this->state.currentLabelReference);
             }
-        } catch(...) {
+        }
+        catch (...)
+        {
             // ignore erroneous nonsense
             this->state.currentLabelReference.name = "";
         }
@@ -226,10 +229,10 @@ void AsmParser::ObjDumpParser::undo_last_line_if_label()
     if (lastLine.is_label)
     {
         std::erase_if(this->labels,
-                        [lastLine](auto &label)
-                        {
-                            return label.first == lastLine.label;
-                        });
+                      [lastLine](auto &label)
+                      {
+                          return label.first == lastLine.label;
+                      });
         this->lines.pop_back();
     }
 }
@@ -244,8 +247,7 @@ void AsmParser::ObjDumpParser::do_file_check(std::string_view filename)
         {
             if (this->lines.size() > 0)
             {
-                // undo previous line if that was a label (it's a label in a library file)
-                undo_last_line_if_label()
+                undo_last_line_if_label();
             }
 
             this->state.commonReset();

--- a/src/objdump/parser.hpp
+++ b/src/objdump/parser.hpp
@@ -50,6 +50,7 @@ class ObjDumpParser : public IParser
     void actually_address();
     void actually_filename();
     void do_file_check(std::string_view filename);
+    void undo_last_line_if_label();
 
     bool shouldIgnoreFunction(const std::string_view name) const;
     void eol();

--- a/src/objdump/parser.hpp
+++ b/src/objdump/parser.hpp
@@ -3,6 +3,7 @@
 #include "../types/filter.hpp"
 #include "../types/line.hpp"
 #include "../types/parser.hpp"
+#include "../utils/library_detection.hpp"
 #include <iosfwd>
 #include <string_view>
 #include <unordered_map>
@@ -43,6 +44,7 @@ class ObjDumpParser : public IParser
     private:
     const Filter filter;
     ObjDumpParserState state{};
+    LibraryDetection lib_detection;
     std::vector<asm_line> lines;
     std::vector<asm_labelpair_t> labels;
 

--- a/src/objdump/parser.hpp
+++ b/src/objdump/parser.hpp
@@ -25,6 +25,7 @@ class ObjDumpParserState
     bool skipRestOfTheLine{};
     bool stopParsing{};
     bool ignoreUntilNextLabel{};
+    bool checkNextFileForLibraryCode{};
 
     asm_label currentLabelReference{};
     asm_source currentSourceRef{};
@@ -48,6 +49,7 @@ class ObjDumpParser : public IParser
     // todo: bad names
     void actually_address();
     void actually_filename();
+    void do_file_check(std::string_view filename);
 
     bool shouldIgnoreFunction(const std::string_view name) const;
     void eol();

--- a/src/utils/jsonwriter.cpp
+++ b/src/utils/jsonwriter.cpp
@@ -1,7 +1,7 @@
 #include "jsonwriter.hpp"
+#include "utils.hpp"
 #include <algorithm>
 #include <ostream>
-#include "utils.hpp"
 
 AsmParser::JsonWriter::JsonWriter(std::ostream &out,
                                   const std::vector<std::unique_ptr<asm_line_v>> &lines,
@@ -179,10 +179,13 @@ void AsmParser::JsonWriter::writeSource(const asm_line_v *line)
             {
                 this->writeKvNull("file", jsonopt::trailingcomma);
             }
-            else if (line->source.file.starts_with("/app/")) {
+            else if (line->source.file.starts_with("/app/"))
+            {
                 const auto withoutapp = std::string_view(line->source.file.begin() + 5, line->source.file.end());
                 this->writeKv("file", withoutapp, jsonopt::trailingcomma);
-            } else {
+            }
+            else
+            {
                 this->writeKv("file", line->source.file, jsonopt::trailingcomma);
             }
         }
@@ -379,7 +382,7 @@ void AsmParser::JsonWriter::JsonWriter::write()
         }
     }
     this->out << "},";
-    
+
     this->writeKv("parsingTime", global_current_running_time(), jsonopt::none);
 
     this->out << "}";

--- a/src/utils/library_detection.cpp
+++ b/src/utils/library_detection.cpp
@@ -1,0 +1,11 @@
+#include "library_detection.hpp"
+
+AsmParser::LibraryDetection::LibraryDetection()
+{
+}
+
+bool AsmParser::LibraryDetection::file_in_library(std::string_view filepath) const
+{
+    return filepath.starts_with("/opt/compiler-explorer/") || filepath.starts_with("/usr/include") ||
+           filepath.starts_with("/usr/local/include");
+}

--- a/src/utils/library_detection.hpp
+++ b/src/utils/library_detection.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string_view>
+
+namespace AsmParser
+{
+
+class LibraryDetection
+{
+    public:
+    LibraryDetection();
+
+    bool file_in_library(std::string_view filepath) const;
+};
+
+} // namespace AsmParser

--- a/src/utils/regexwrappers.cpp
+++ b/src/utils/regexwrappers.cpp
@@ -290,12 +290,6 @@ bool AsmParser::AssemblyTextParserUtils::isExampleOrStdin(const std::string_view
     return false;
 }
 
-bool AsmParser::AssemblyTextParserUtils::isProbablyLibraryFile(std::string_view filename)
-{
-    return filename.starts_with("/opt/compiler-explorer/") || filename.starts_with("/usr/include") ||
-           filename.starts_with("/usr/local/include");
-}
-
 std::optional<AsmParser::asm_stabn> AsmParser::AssemblyTextParserUtils::getSourceInfoFromStabs(const std::string_view line)
 {
     const auto match = Regexes::sourceStab(line);

--- a/src/utils/regexwrappers.cpp
+++ b/src/utils/regexwrappers.cpp
@@ -438,6 +438,16 @@ std::optional<std::string_view> AsmParser::AssemblyTextParserUtils::getLabel(con
     return std::nullopt;
 }
 
+std::optional<std::string_view> AsmParser::AssemblyTextParserUtils::getLabelFromObjdumpLabel(std::string_view line)
+{
+    if (line.starts_with("<") && line.ends_with(">:"))
+    {
+        return std::string_view{ line.begin() + 1, line.end() - 2 };
+    }
+
+    return std::nullopt;
+}
+
 std::optional<std::string_view> AsmParser::AssemblyTextParserUtils::getLabelAssignment(const std::string_view line)
 {
     if (const auto matchAssign = Regexes::labelAssignmentDef(line))

--- a/src/utils/regexwrappers.cpp
+++ b/src/utils/regexwrappers.cpp
@@ -287,9 +287,8 @@ bool AsmParser::AssemblyTextParserUtils::isExampleOrStdin(const std::string_view
 
 bool AsmParser::AssemblyTextParserUtils::isProbablyLibraryFile(std::string_view filename)
 {
-    return filename.starts_with("/opt/compiler-explorer/") ||
-        filename.starts_with("/usr/include") ||
-        filename.starts_with("/usr/local/include");
+    return filename.starts_with("/opt/compiler-explorer/") || filename.starts_with("/usr/include") ||
+           filename.starts_with("/usr/local/include");
 }
 
 std::optional<AsmParser::asm_stabn> AsmParser::AssemblyTextParserUtils::getSourceInfoFromStabs(const std::string_view line)

--- a/src/utils/regexwrappers.cpp
+++ b/src/utils/regexwrappers.cpp
@@ -285,6 +285,13 @@ bool AsmParser::AssemblyTextParserUtils::isExampleOrStdin(const std::string_view
     return false;
 }
 
+bool AsmParser::AssemblyTextParserUtils::isProbablyLibraryFile(std::string_view filename)
+{
+    return filename.starts_with("/opt/compiler-explorer/") ||
+        filename.starts_with("/usr/include") ||
+        filename.starts_with("/usr/local/include");
+}
+
 std::optional<AsmParser::asm_stabn> AsmParser::AssemblyTextParserUtils::getSourceInfoFromStabs(const std::string_view line)
 {
     const auto match = Regexes::sourceStab(line);

--- a/src/utils/regexwrappers.hpp
+++ b/src/utils/regexwrappers.hpp
@@ -36,7 +36,6 @@ class AssemblyTextParserUtils
     static bool hasOpcode(const std::string_view line, bool inNvccCode);
 
     static bool isExampleOrStdin(const std::string_view filename);
-    static bool isProbablyLibraryFile(std::string_view filename);
 
     static bool isJustComments(const std::string_view line);
     static bool isJustNvccComments(const std::string_view line);

--- a/src/utils/regexwrappers.hpp
+++ b/src/utils/regexwrappers.hpp
@@ -36,6 +36,7 @@ class AssemblyTextParserUtils
     static bool hasOpcode(const std::string_view line, bool inNvccCode);
 
     static bool isExampleOrStdin(const std::string_view filename);
+    static bool isProbablyLibraryFile(std::string_view filename);
 
     static bool isJustComments(const std::string_view line);
     static bool isJustNvccComments(const std::string_view line);

--- a/src/utils/regexwrappers.hpp
+++ b/src/utils/regexwrappers.hpp
@@ -56,6 +56,8 @@ class AssemblyTextParserUtils
     static std::optional<std::string_view> getGlobalDefinedLabel(const std::string_view line);
     static std::optional<std::string_view> getSectionNameDef(const std::string_view line);
 
+    static std::optional<std::string_view> getLabelFromObjdumpLabel(std::string_view line);
+
     static bool startCommentBlock(const std::string_view line);
     static bool endCommentBlock(const std::string_view line);
 


### PR DESCRIPTION
this exercise unearth some strange codepaths that should probably be cleaned up,
demangling also messes things up, but its ok now i think

though should probably test with different kind of objdump files, like 32 bit and older versions of objdump

but for now, this works