### PR TITLE
fixed missing cstdint header

### DIFF
--- a/src/types/line.hpp
+++ b/src/types/line.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>


### PR DESCRIPTION
`cstdint` is missing in the includes. Old versions of stdlibc++ include it in most headers so this isn't a problem on old Linux distros but it does trigger an error on distros with an up-to-date GCC installation like Arch Linux. This single-line commit fixes that.